### PR TITLE
Use release tag in config

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -10,7 +10,7 @@ start_date: 2025-08-04
 end_date: 2025-08-08
 # Specific release in AlexsLemonade/training-modules
 # We use master to make development easier
-release_tag: master
+release_tag: 2025-august
 
 #### Workshop information ####
 workshop_type: "remote"    # Update this value to either: "remote" or "in-person"
@@ -28,7 +28,7 @@ instructors:
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
 docker_repo: training_rstudio
-docker_tag: edge
+docker_tag: 2025-august
 # These are for loading Docker images from a file; only relevant for in-person
 docker_targz: ccdl_docker_image.tar.gz
 docker_tar: ccdl_docker_image.tar


### PR DESCRIPTION
Closes #6 

This PR fills in the `release_tag` and `docker_tag` values with the new release which has been made: https://github.com/AlexsLemonade/training-modules/releases/tag/2025-august